### PR TITLE
chore: update equatable and dartz dependencies versions

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,10 +8,10 @@ environment:
   sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
-  equatable: ^2.0.2
+  equatable: ^2.0.3
 
   # Functional programming
-  dartz: ^0.10.0-nullsafety.2
+  dartz: ^0.10.1
 
 dev_dependencies:
   # Linting and Code analysis


### PR DESCRIPTION
  equatable: ^2.0.3
  dartz: ^0.10.1